### PR TITLE
Fixed typographical error, changed absolutly to absolutely in README.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -110,7 +110,7 @@ fn1. Use this to get a Transaction object then you can @begin()@ or @commit()@ o
 
 fn2. Use this to lock an object across the cluster.
 
-fn3. Use this if you absolutly _NEED_ to directly get the Default Hazelcast instance.
+fn3. Use this if you absolutely _NEED_ to directly get the Default Hazelcast instance.
 
 h2. Hibernate second level cache configuration
 


### PR DESCRIPTION
@marcuspocus, I've corrected a typographical error in the documentation of the [hazelcast](https://github.com/marcuspocus/hazelcast) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.